### PR TITLE
feat: add API for creating direct message channels

### DIFF
--- a/backend/src/routes/chat.route.js
+++ b/backend/src/routes/chat.route.js
@@ -5,6 +5,7 @@ import {
     createChannel,
     addMembersToChannel,
     getChannelMembers,
+    createDirectMessage,
     getMessages,
     sendMessage
 } from "../controllers/chat.controller.js";
@@ -18,6 +19,7 @@ router.post("/channels", protectRoute, createChannel);
 router.post("/channels/:channelId/members", protectRoute, addMembersToChannel);
 router.get("/channels/:channelId/members", protectRoute, getChannelMembers);
 router.get("/channels", protectRoute, getChannels);
+router.post("/direct-messages", protectRoute, createDirectMessage);
 router.get("/messages/:channelId", protectRoute, getMessages);
 router.post("/messages", protectRoute, sendMessage);
 


### PR DESCRIPTION
This pull request adds support for creating direct message (DM) channels between two users in the chat backend. The main change is the introduction of a new API endpoint for creating DMs, with proper input validation, error handling, and integration with the Stream chat service. The routes and controller logic have been updated accordingly.

**Direct Message (DM) channel support:**

* Added a new `createDirectMessage` controller in `chat.controller.js` to handle the creation of private DM channels between two users, including input validation, prevention of self-DM, channel creation/upsert logic, and detailed error handling.
* Registered the new `createDirectMessage` controller in the router and exposed a new POST endpoint `/direct-messages` for creating DM channels. [[1]](diffhunk://#diff-ad142749870790e27c45db226ab13643072985a622b29df7f4d423396a0e0c6aR8) [[2]](diffhunk://#diff-ad142749870790e27c45db226ab13643072985a622b29df7f4d423396a0e0c6aR22)